### PR TITLE
Remove revenue mention from Avatarify

### DIFF
--- a/index.html
+++ b/index.html
@@ -174,7 +174,7 @@
             <p class="details">01 May 2020 • iOS, Android, Telegram</p>
             <ul>
                 <li>Makes any photo sing with AI</li>
-                <li><b>14M+</b> users, <b>$3M+</b> revenue, <b>1B+</b> views on socials, <b>50M+</b> videos generated</li>
+                <li><b>14M+</b> users, <b>1B+</b> views on socials, <b>50M+</b> videos generated</li>
                 <li>Media: <a href="https://techcrunch.com/2021/04/14/deep-fake-video-app-avatarify-which-process-on-phone-plans-digital-watermark-for-videos/?guccounter=1" target="_blank">TechCrunch</a>, <a href="https://www.washingtonpost.com/technology/2021/03/25/deepfake-video-apps/" target="_blank">The Washington Post</a></li>
                 <li>Telegram version: <a href="https://t.me/avatarify_bot" target="_blank">@avatarify_bot</a></li>
             </ul>


### PR DESCRIPTION
## Summary
- remove the $3M+ revenue phrase from the Avatarify AI project description

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6956ad95f1c08323bbf1c730d65584fe)